### PR TITLE
add image generation api and routes

### DIFF
--- a/src/api-docs.yaml
+++ b/src/api-docs.yaml
@@ -15,6 +15,7 @@ paths:
             text/plain:
               schema:
                 type: string
+
   /v1/models:
     get:
       summary: Fetch available models
@@ -92,6 +93,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /v1/images/generations:
+    post:
+      summary: Generate images
+      description: Proxy to upstream LLM for image generation.
+      parameters:
+        - in: header
+          name: x-llm-base-url
+          required: true
+          schema:
+            type: string
+          description: Base URL of the LLM service
+        - in: header
+          name: x-llm-api-key
+          required: true
+          schema:
+            type: string
+          description: Your LLM API key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateImageRequest'
+      responses:
+        '200':
+          description: The image generation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageResponse'
+        '400':
+          description: Missing headers or bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+
 components:
   schemas:
     Message:
@@ -151,3 +190,35 @@ components:
       properties:
         error:
           type: string
+
+    GenerateImageRequest:
+      type: object
+      required:
+        - prompt
+      properties:
+        prompt:
+          type: string
+          description: Text prompt to generate the image
+        model:
+          type: string
+          description: Model to use for image generation
+        n:
+          type: integer
+          description: Number of images to generate
+        size:
+          type: string
+          description: Dimensions of the generated image (e.g. "1024x1024")
+    ImageResponse:
+      type: object
+      properties:
+        created:
+          type: integer
+          description: Timestamp of image creation
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+                description: URL of the generated image

--- a/src/routes/llm.ts
+++ b/src/routes/llm.ts
@@ -1,5 +1,15 @@
-import { Router, Request, Response, NextFunction } from 'express';
-import { getModels, getCompletion, streamCompletion } from '../utils/llm_gateway_client';
+import { 
+    Router, 
+    Request, 
+    Response, 
+    NextFunction 
+} from 'express';
+import { 
+    getModels, 
+    getCompletion, 
+    streamCompletion,
+    generateImage 
+} from '../utils/llm_gateway_client';
 
 const router = Router();
 
@@ -52,6 +62,26 @@ router.post(
       next(err);
     }
   }
+);
+
+router.post(
+    '/images/generations',
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const baseUrl = req.header('x-llm-base-url')!;
+            const apiKey = req.header('x-llm-api-key')!;
+            if (!baseUrl || !apiKey) {
+              res.status(400).json({
+                error: 'x-llm-base-url and x-llm-api-key headers are required'
+              });
+            }
+            const request = req.body;
+            const response = await generateImage(baseUrl, apiKey, request);
+            res.json(response);
+        } catch (err) {
+            next(err);
+        }
+    }
 );
 
 export default router;

--- a/src/utils/llm_gateway_client.ts
+++ b/src/utils/llm_gateway_client.ts
@@ -1,7 +1,9 @@
 import { 
     model, 
-    chatRequest, 
-    chatCompletion 
+    chatRequest,
+    chatCompletion,
+    generateImageRequest,
+    imageResponse
 } from "@innobridge/llmclient";
 
 const getModels = async (baseUrl: string, apiKey: string): Promise<model.Models> => {
@@ -78,9 +80,37 @@ export async function* streamCompletion(
       if (done) break;
       yield decoder.decode(value);
     }
-  }
+};
+
+const generateImage = async (
+    baseUrl: string, 
+    apiKey: string, 
+    request: generateImageRequest.GenerateImageRequest): Promise<imageResponse.ImageResponse> => {
+    try {
+        const response = await fetch(`${baseUrl}/v1/images/generations`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(request)
+        });
+        
+        if (!response.ok) {
+            const errJson = await response.json();
+            throw new Error(`HTTP error! status: ${errJson.error.message}`);
+        }
+        
+        const data = await response.json();
+        return data as imageResponse.ImageResponse;
+    } catch (error: any) {
+        console.error('Error generating image:', error.message);
+        throw error;
+    }
+};
 
 export {
     getModels,
-    getCompletion
+    getCompletion,
+    generateImage
 };


### PR DESCRIPTION
This pull request introduces functionality for image generation via a new API endpoint. It includes updates to the OpenAPI specification, backend routing, and utility functions to support this feature.

### API Specification Updates:
* Added a new `POST /v1/images/generations` endpoint in `src/api-docs.yaml` for generating images. It includes headers for the LLM base URL and API key, a request body schema (`GenerateImageRequest`), and a response schema (`ImageResponse`).
* Defined new schemas in `src/api-docs.yaml`: `GenerateImageRequest` (specifies the image generation prompt, model, count, and size) and `ImageResponse` (details the image creation timestamp and URLs).

### Backend Routing:
* Added a new route in `src/routes/llm.ts` (`POST /images/generations`) to handle image generation requests. It validates headers, forwards the request to the utility function, and returns the response.
* Updated imports in `src/routes/llm.ts` to include the `generateImage` function.

### Utility Function:
* Implemented a `generateImage` function in `src/utils/llm_gateway_client.ts` to interact with the upstream LLM service for image generation. It sends a POST request with the required headers and body, handles errors, and returns the response.
* Updated exports in `src/utils/llm_gateway_client.ts` to include the new `generateImage` function.